### PR TITLE
fix(ckanext.requestdata.controllers.package): fixed a regression in package controller module

### DIFF
--- a/ckanext/requestdata/controllers/package.py
+++ b/ckanext/requestdata/controllers/package.py
@@ -12,7 +12,12 @@ get_action = logic.get_action
 NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError
 clean_dict = logic.clean_dict
-redirect = base.redirect
+try:
+    # Support CKAN 2.6
+    redirect = base.redirect
+except AttributeError:
+    # Redirect is now redirect_to in CKAN 2.7
+    redirect = h.redirect_to
 abort = base.abort
 tuplize_dict = logic.tuplize_dict
 parse_params = logic.parse_params


### PR DESCRIPTION
…ackage controller module

in ckan 2.7.x ckan.lib.base.redirect has been removed, using ckan.lib.helpers.redirect_to instead